### PR TITLE
Make "No plates found" message a bit more helpful

### DIFF
--- a/slackbot/bot.py
+++ b/slackbot/bot.py
@@ -277,7 +277,7 @@ class Bot:
         self.post_chat_messge(channels, file_id, msg, "Low confidence")
 
     def comment_no_plates_found(self, channels, file_id):
-        self.post_chat_messge(channels, file_id, "No plates were found", "No plates found")
+        self.post_chat_messge(channels, file_id, "No plates were found. Try `/kenteken [license plate]` if _you_ can OCR a license plate from that image.", "No plates found")
 
     def comment_with_match(self, channels, file_id, plate, confidence, details):
         if details:


### PR DESCRIPTION
... pointing to `/kenteken` slash command.

TODO: Change that reference if the `/kenteken` command is renamed to `/car`.